### PR TITLE
fix: parse detached modifier content

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,28 @@ mod tests {
     }
 
     #[test]
+    fn modifier_extensions() {
+        let examples: Vec<_> = [
+            "- ( ) undone",
+            "* (x) done",
+            "- (=) hold",
+            "* (_) canceled",
+            "- (-) pending",
+            "* (!) urgent",
+            "- (+) recurring",
+            "~ (+ Friday) recurring with date",
+            "** ( |# Low|< Feb 1) undone, low, & before Feb",
+            "** (# Two Words|x| |!|+|_|+ 5th|=|-|< Feb 1|> 2025|@ Jan 1 2025) All of them"
+        ].into_iter()
+        .map(|example| example.to_string() + "\n")
+        .map(|str| parse(&str))
+        .try_collect()
+        .unwrap();
+
+        assert_yaml_snapshot!(examples);
+    }
+
+    #[test]
     fn lists_regressions() {
         [
             "- - a list item",

--- a/src/snapshots/rust_norg__tests__modifier_extensions.snap
+++ b/src/snapshots/rust_norg__tests__modifier_extensions.snap
@@ -1,0 +1,134 @@
+---
+source: src/lib.rs
+expression: examples
+---
+- - NestableDetachedModifier:
+      modifier_type: UnorderedList
+      level: 1
+      extensions:
+        - Todo: Undone
+      content:
+        Paragraph:
+          - Token:
+              Text: undone
+- - Heading:
+      level: 1
+      title:
+        - Token: Whitespace
+        - Token:
+            Text: done
+      extensions:
+        - Todo: Done
+- - NestableDetachedModifier:
+      modifier_type: UnorderedList
+      level: 1
+      extensions:
+        - Todo: Paused
+      content:
+        Paragraph:
+          - Token:
+              Text: hold
+- - Heading:
+      level: 1
+      title:
+        - Token: Whitespace
+        - Token:
+            Text: canceled
+      extensions:
+        - Todo: Canceled
+- - NestableDetachedModifier:
+      modifier_type: UnorderedList
+      level: 1
+      extensions:
+        - Todo: Pending
+      content:
+        Paragraph:
+          - Token:
+              Text: pending
+- - Heading:
+      level: 1
+      title:
+        - Token: Whitespace
+        - Token:
+            Text: urgent
+      extensions:
+        - Todo: Urgent
+- - NestableDetachedModifier:
+      modifier_type: UnorderedList
+      level: 1
+      extensions:
+        - Todo:
+            Recurring: ~
+      content:
+        Paragraph:
+          - Token:
+              Text: recurring
+- - NestableDetachedModifier:
+      modifier_type: OrderedList
+      level: 1
+      extensions:
+        - Todo:
+            Recurring: Friday
+      content:
+        Paragraph:
+          - Token:
+              Text: recurring
+          - Token: Whitespace
+          - Token:
+              Text: with
+          - Token: Whitespace
+          - Token:
+              Text: date
+- - Heading:
+      level: 2
+      title:
+        - Token: Whitespace
+        - Token:
+            Text: undone
+        - Token:
+            Special: ","
+        - Token: Whitespace
+        - Token:
+            Text: low
+        - Token:
+            Special: ","
+        - Token: Whitespace
+        - Token:
+            Text: "&"
+        - Token: Whitespace
+        - Token:
+            Text: before
+        - Token: Whitespace
+        - Token:
+            Text: Feb
+      extensions:
+        - Todo: Undone
+        - Priority: Low
+        - DueDate: Feb 1
+- - Heading:
+      level: 2
+      title:
+        - Token: Whitespace
+        - Token:
+            Text: All
+        - Token: Whitespace
+        - Token:
+            Text: of
+        - Token: Whitespace
+        - Token:
+            Text: them
+      extensions:
+        - Priority: Two Words
+        - Todo: Done
+        - Todo: Undone
+        - Todo: Urgent
+        - Todo:
+            Recurring: ~
+        - Todo: Canceled
+        - Todo:
+            Recurring: 5th
+        - Todo: Paused
+        - Todo: Pending
+        - DueDate: Feb 1
+        - StartDate: "2025"
+        - Timestamp: Jan 1 2025

--- a/src/stage_3.rs
+++ b/src/stage_3.rs
@@ -575,7 +575,7 @@ fn detached_modifier_extensions() -> impl Parser<
     let detached_modifier_extension = detached_modifier_extension_tokens
         .then(
             just(Whitespace)
-                .ignore_then(select!(Special('|') => Special('|')).repeated())
+                .ignore_then(select!(Special('|') => Special('|')).not().repeated())
                 .or_not()
                 .map(|tokens| {
                     if let Some(tokens) = tokens {


### PR DESCRIPTION
I'm honestly not sure what I was thinking when I wrote this originally. I also added tests.