### PR TITLE
feat: parse_tree groups list items into Lists

### DIFF
--- a/src/snapshots/rust_norg__tests__carryover_tags_tree.snap
+++ b/src/snapshots/rust_norg__tests__carryover_tags_tree.snap
@@ -69,15 +69,18 @@ expression: examples
               - Token:
                   Text: two
           content:
-            - NestableDetachedModifier:
+            - List:
                 modifier_type: UnorderedList
-                level: 4
-                extensions: []
-                text:
-                  Paragraph:
-                    - Token:
-                        Text: four
-                content: []
+                items:
+                  - NestableDetachedModifier:
+                      modifier_type: UnorderedList
+                      level: 4
+                      extensions: []
+                      text:
+                        Paragraph:
+                          - Token:
+                              Text: four
+                      content: []
             - CarryoverTag:
                 tag_type: Macro
                 name:

--- a/src/snapshots/rust_norg__tests__delimiting_mods_tree.snap
+++ b/src/snapshots/rust_norg__tests__delimiting_mods_tree.snap
@@ -46,15 +46,18 @@ expression: examples
         - Paragraph:
             - Token:
                 Text: two
-- - NestableDetachedModifier:
+- - List:
       modifier_type: UnorderedList
-      level: 1
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: list
-      content: []
+      items:
+        - NestableDetachedModifier:
+            modifier_type: UnorderedList
+            level: 1
+            extensions: []
+            text:
+              Paragraph:
+                - Token:
+                    Text: list
+            content: []
   - DelimitingModifier: HorizontalRule
   - Paragraph:
       - Token:

--- a/src/snapshots/rust_norg__tests__lists_tree.snap
+++ b/src/snapshots/rust_norg__tests__lists_tree.snap
@@ -2,106 +2,127 @@
 source: src/lib.rs
 expression: examples
 ---
-- - NestableDetachedModifier:
+- - List:
       modifier_type: UnorderedList
-      level: 1
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: base
-      content: []
-- - NestableDetachedModifier:
-      modifier_type: UnorderedList
-      level: 1
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: one
-      content:
+      items:
         - NestableDetachedModifier:
             modifier_type: UnorderedList
-            level: 2
+            level: 1
             extensions: []
             text:
               Paragraph:
                 - Token:
-                    Text: two
+                    Text: base
             content: []
-- - NestableDetachedModifier:
+- - List:
       modifier_type: UnorderedList
-      level: 1
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: one
-      content:
+      items:
         - NestableDetachedModifier:
             modifier_type: UnorderedList
-            level: 2
+            level: 1
             extensions: []
             text:
               Paragraph:
                 - Token:
-                    Text: two
-                - Token: Whitespace
-                - Token:
-                    Text: with
-                - Token: Whitespace
-                - Token:
-                    Text: content
-            content: []
-        - NestableDetachedModifier:
-            modifier_type: UnorderedList
-            level: 2
-            extensions: []
-            text:
-              Paragraph:
-                - Token:
-                    Text: two
-                - Token: Whitespace
-                - Token:
-                    Special: (
-                - Token:
-                    Text: "2"
-                - Token:
-                    Special: )
+                    Text: one
             content:
-              - NestableDetachedModifier:
+              - List:
                   modifier_type: UnorderedList
-                  level: 3
-                  extensions: []
-                  text:
-                    Paragraph:
-                      - Token:
-                          Text: three
-                  content: []
-  - NestableDetachedModifier:
+                  items:
+                    - NestableDetachedModifier:
+                        modifier_type: UnorderedList
+                        level: 2
+                        extensions: []
+                        text:
+                          Paragraph:
+                            - Token:
+                                Text: two
+                        content: []
+- - List:
       modifier_type: UnorderedList
-      level: 1
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: one
-      content: []
-- - NestableDetachedModifier:
+      items:
+        - NestableDetachedModifier:
+            modifier_type: UnorderedList
+            level: 1
+            extensions: []
+            text:
+              Paragraph:
+                - Token:
+                    Text: one
+            content:
+              - List:
+                  modifier_type: UnorderedList
+                  items:
+                    - NestableDetachedModifier:
+                        modifier_type: UnorderedList
+                        level: 2
+                        extensions: []
+                        text:
+                          Paragraph:
+                            - Token:
+                                Text: two
+                            - Token: Whitespace
+                            - Token:
+                                Text: with
+                            - Token: Whitespace
+                            - Token:
+                                Text: content
+                        content: []
+                    - NestableDetachedModifier:
+                        modifier_type: UnorderedList
+                        level: 2
+                        extensions: []
+                        text:
+                          Paragraph:
+                            - Token:
+                                Text: two
+                            - Token: Whitespace
+                            - Token:
+                                Special: (
+                            - Token:
+                                Text: "2"
+                            - Token:
+                                Special: )
+                        content:
+                          - List:
+                              modifier_type: UnorderedList
+                              items:
+                                - NestableDetachedModifier:
+                                    modifier_type: UnorderedList
+                                    level: 3
+                                    extensions: []
+                                    text:
+                                      Paragraph:
+                                        - Token:
+                                            Text: three
+                                    content: []
+        - NestableDetachedModifier:
+            modifier_type: UnorderedList
+            level: 1
+            extensions: []
+            text:
+              Paragraph:
+                - Token:
+                    Text: one
+            content: []
+- - List:
       modifier_type: UnorderedList
-      level: 2
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: two
-      content: []
-  - NestableDetachedModifier:
-      modifier_type: UnorderedList
-      level: 1
-      extensions: []
-      text:
-        Paragraph:
-          - Token:
-              Text: one
-      content: []
+      items:
+        - NestableDetachedModifier:
+            modifier_type: UnorderedList
+            level: 2
+            extensions: []
+            text:
+              Paragraph:
+                - Token:
+                    Text: two
+            content: []
+        - NestableDetachedModifier:
+            modifier_type: UnorderedList
+            level: 1
+            extensions: []
+            text:
+              Paragraph:
+                - Token:
+                    Text: one
+            content: []

--- a/src/stage_3.rs
+++ b/src/stage_3.rs
@@ -7,7 +7,7 @@ use textwrap::dedent;
 
 use crate::stage_2::{NorgBlock, ParagraphSegmentToken, ParagraphTokenList};
 
-#[derive(Clone, Hash, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Serialize)]
 pub enum NestableDetachedModifier {
     Quote,
     UnorderedList,


### PR DESCRIPTION
list items are grouped into List objects now. Allows for correct HTML list generation in norgolith.

Lists are still parsed a little inaccurately by the parser. Consider this example:

```
- one list
- first list

- new list
- part of the new list
```

This is parsed as a single list, b/c stage 1-3 throw away the blank line